### PR TITLE
feat: Add Loading Spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 1.0.0 (2022-09-19)
+
+### Features
+
+- add loading spinner and file upload control ([6190e7b](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/6190e7be675a98c1a74b89d43f494d42bdf5f598))
+- add onDelete interceptor ([710f937](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/710f93710bb67c42ab6b2fe5ba2075cef1fe1483))
+- add spinner ([d8ca826](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/d8ca82660fad7941e4da524ce0a4232faf2f97d6))
+- create upload compenent and stories ([b1569df](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/b1569df1388c520a1a6c6e6bff66eb39481828d5))
+- expose buttonProps to customize the upload button ([3702de1](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/3702de1035b0179952a94c168760e1bdeced8422))
+- setup storybook ([4e6a718](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/4e6a7180e3820cfa84c638dc8a5730a47512907d))
+
+### Bug Fixes
+
+- lint issues ([9c6b26b](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/9c6b26b030b71b2e346f84c6897a85c5e8cf2526))
+
+### 1.0.0 (2022-09-19)
+
+### Features
+
+- add loading spinner and file upload control ([6190e7b](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/6190e7be675a98c1a74b89d43f494d42bdf5f598))
+- add onDelete interceptor ([710f937](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/710f93710bb67c42ab6b2fe5ba2075cef1fe1483))
+- add spinner ([d8ca826](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/d8ca82660fad7941e4da524ce0a4232faf2f97d6))
+- create upload compenent and stories ([b1569df](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/b1569df1388c520a1a6c6e6bff66eb39481828d5))
+- expose buttonProps to customize the upload button ([3702de1](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/3702de1035b0179952a94c168760e1bdeced8422))
+- setup storybook ([4e6a718](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/4e6a7180e3820cfa84c638dc8a5730a47512907d))
+
+### Bug Fixes
+
+- lint issues ([9c6b26b](https://github.com/klinikum-evb/react-material-file-upload-spinner/commit/9c6b26b030b71b2e346f84c6897a85c5e8cf2526))
+
 ### [0.0.4](https://github.com/iamchathu/react-material-file-upload/compare/v0.0.3...v0.0.4) (2021-10-18)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -24,29 +24,61 @@ Library is depends on `@mui/material`, `@mui/icons-material`, `@emotion/react`, 
 
 ```ts
 import { useState } from 'react';
-import FileUpload from 'react-material-file-upload';
+import FileUpload, { LoadingFile } from 'react-material-file-upload';
 
 const App = () => {
-  const [files, setFiles] = useState<File[]>([]);
-  const validateDeletion = (file: File) => file.name === 'i-can-be-deleted.jpg';
-  return <FileUpload value={files} onChange={setFiles} onDelete={validateDeletion} />;
-};
-```
-
-You can also intercept the deletion of an item.
-
-```ts
-import { useState } from 'react';
-import FileUpload from 'react-material-file-upload';
-
-const App = () => {
-  const [files, setFiles] = useState<File[]>([]);
-  const validateDeletion = (file: File) => file.name === 'i-can-be-deleted.jpg'; // return true to delete the item
+  const [files, setFiles] = useState<LoadingFile[]>([]);
+  const validateDeletion = (file: LoadingFile) => file.name === 'i-can-be-deleted.jpg';
   return <FileUpload value={files} onChange={setFiles} onDelete={validateDeletion} />;
 };
 ```
 
 [![Edit react-material-file-upload](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/react-material-file-upload-t156i?fontsize=14&hidenavigation=1&theme=dark)
+
+You can also control the deletion of an item.
+
+```ts
+import { useState } from 'react';
+import FileUpload, { LoadingFile } from 'react-material-file-upload';
+
+const App = () => {
+  const [files, setFiles] = useState<LoadingFile[]>([]);
+  const validateDeletion = (file: LoadingFile) => file.name === 'i-can-be-deleted.jpg'; // return true to delete the item
+  return <FileUpload value={files} onChange={setFiles} onDelete={validateDeletion} />;
+};
+```
+
+To show and control the loading spinner while the file is being uploaded, set the loading state at the addition of new files:
+
+```ts
+import { useState } from 'react';
+import FileUpload, { LoadingFile } from 'react-material-file-upload';
+
+const App = () => {
+  const [files, setFiles] = useState<LoadingFile[]>([]);
+
+  const handleNewFiles = (newFiles: LoadingFile[]) => {
+    newFiles.forEach(async (file) => {
+      file.isLoading = true;
+      file.abortController = new AbortController(); // allows us to abort the file upload in `handleDelete`
+      await uploadFile(file)
+        .then(() => {
+          file.isLoading = false;
+        })
+        .catch((error) => {
+          if (error.name !== 'AbortError') throw error; // we do not want to show the AbortError as the user decided to abort the upload
+        });
+    });
+  };
+
+  const handleDelete = (file: LoadingFile) => {
+    file.abortController?.abort();
+    return true;
+  };
+
+  return <FileUpload value={files} onChange={setFiles} onDelete={handleDelete} onAddFiles={handleNewFiles} />;
+};
+```
 
 [react-dropzone]: https://react-dropzone.js.org/
 [mui]: https://mui.com

--- a/README.md
+++ b/README.md
@@ -28,7 +28,21 @@ import FileUpload from 'react-material-file-upload';
 
 const App = () => {
   const [files, setFiles] = useState<File[]>([]);
-  return <FileUpload value={files} onChange={setFiles} />;
+  const validateDeletion = (file: File) => file.name === 'i-can-be-deleted.jpg';
+  return <FileUpload value={files} onChange={setFiles} onDelete={validateDeletion} />;
+};
+```
+
+You can also intercept the deletion of an item.
+
+```ts
+import { useState } from 'react';
+import FileUpload from 'react-material-file-upload';
+
+const App = () => {
+  const [files, setFiles] = useState<File[]>([]);
+  const validateDeletion = (file: File) => file.name === 'i-can-be-deleted.jpg'; // return true to delete the item
+  return <FileUpload value={files} onChange={setFiles} onDelete={validateDeletion} />;
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,19 +8,21 @@
   "files": [
     "lib"
   ],
-  "repository": "https://github.com/iamchathu/react-material-file-upload.git",
-  "author": "Chathu Vishwajith <iam@chathu.me>",
+  "repository": "https://github.com/klinikum-evb/react-material-file-upload-spinner.git",
+  "author": "Silvan Verhoeven <SilvanVerhoeven@github.com>",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf lib/",
     "tsc": "tsc -b .",
     "build": "rollup -c",
-    "prepare": "install-peers && husky install",
+    "prepare": "husky install",
     "lint": "eslint 'src/**/*.{ts,tsx}' --quiet --fix ",
     "prepublishOnly": "yarn clean && yarn build",
     "release": "standard-version",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "install-peers": "install-peers",
+    "postinstall": "yarn install-peers && yarn build"
   },
   "peerDependencies": {
     "@emotion/react": "^11.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-material-file-upload",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "File upload compoennt for React with Material UI components",
   "main": "lib/index.js",
   "module": "lib/index.esm.js",
@@ -15,7 +15,7 @@
     "clean": "rimraf lib/",
     "tsc": "tsc -b .",
     "build": "rollup -c",
-    "prepare": "husky install",
+    "prepare": "install-peers && husky install",
     "lint": "eslint 'src/**/*.{ts,tsx}' --quiet --fix ",
     "prepublishOnly": "yarn clean && yarn build",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "prepublishOnly": "yarn clean && yarn build",
     "release": "standard-version",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook",
-    "install-peers": "install-peers",
-    "postinstall": "yarn install-peers && yarn build"
+    "build-storybook": "build-storybook"
   },
   "peerDependencies": {
     "@emotion/react": "^11.4.1",

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -1,24 +1,53 @@
-import UploadFileIcon from '@mui/icons-material/UploadFile';
-import { Chip, CircularProgress } from '@mui/material';
-import { styled } from '@mui/material/styles';
+import UploadFileIcon from "@mui/icons-material/UploadFile"
+import { Box, Chip, CircularProgress } from "@mui/material"
+import { styled } from "@mui/material/styles"
 
+/**
+ * Extension of `File` providing optional attributes to display and control a loading file.
+ *
+ * @param abortController Allows us to control the up/downloading request for this file. See https://developer.mozilla.org/en-US/docs/Web/API/AbortController.
+ * @param isLoading If true, the FileListItem shows a spinner to indicate that the file is loading. Spinner details: https://mui.com/material-ui/react-progress/.
+ * @param progress If set, we can control the spinner's displayed progress. Should be between `0` and `100`.
+ */
 export interface LoadingFile extends File {
+  abortController?: AbortController
   isLoading?: boolean
+  progress?: number
 }
 
 export interface FileListItemProps {
-  file: LoadingFile;
-  onDelete: (file: LoadingFile) => void;
+  file: LoadingFile
+  onDelete: (file: LoadingFile) => void
 }
 
-const ListItem = styled('li')(({ theme }) => ({
+const ListItem = styled("li")(({ theme }) => ({
   margin: theme.spacing(0.5),
-}));
+}))
 
 const FileListItem = ({ file, onDelete }: FileListItemProps) => (
-  <ListItem>
-    <Chip label={file.name} icon={!file.isLoading ? <CircularProgress size={20} /> : <UploadFileIcon />} variant="outlined" sx={{ maxWidth: 200 }} onDelete={() => onDelete(file)} />
-  </ListItem>
-);
+    <ListItem>
+      <Chip
+        label={file.name}
+        icon={
+          file.isLoading ? (
+            <Box>
+              <CircularProgress
+                variant={file.progress === undefined ? "indeterminate" : "determinate"}
+                size={20}
+                value={file.progress}
+                color="inherit"
+                sx={{ mr: 0.5 }}
+              />
+            </Box>
+          ) : (
+            <UploadFileIcon />
+          )
+        }
+        variant="outlined"
+        sx={{ maxWidth: 200 }}
+        onDelete={() => onDelete(file)}
+      />
+    </ListItem>
+  )
 
-export default FileListItem;
+export default FileListItem

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -3,17 +3,17 @@ import { Chip } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 export interface FileListItemProps {
-  name: string;
-  onDelete: () => void;
+  file: File;
+  onDelete: (file: File) => void;
 }
 
 const ListItem = styled('li')(({ theme }) => ({
   margin: theme.spacing(0.5),
 }));
 
-const FileListItem = ({ name, onDelete }: FileListItemProps) => (
+const FileListItem = ({ file, onDelete }: FileListItemProps) => (
   <ListItem>
-    <Chip label={name} icon={<UploadFileIcon />} variant="outlined" sx={{ maxWidth: 200 }} onDelete={onDelete} />
+    <Chip label={file.name} icon={<UploadFileIcon />} variant="outlined" sx={{ maxWidth: 200 }} onDelete={() => onDelete(file)} />
   </ListItem>
 );
 

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -1,10 +1,14 @@
 import UploadFileIcon from '@mui/icons-material/UploadFile';
-import { Chip } from '@mui/material';
+import { Chip, CircularProgress } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
+export interface LoadingFile extends File {
+  isLoading?: boolean
+}
+
 export interface FileListItemProps {
-  file: File;
-  onDelete: (file: File) => void;
+  file: LoadingFile;
+  onDelete: (file: LoadingFile) => void;
 }
 
 const ListItem = styled('li')(({ theme }) => ({
@@ -13,7 +17,7 @@ const ListItem = styled('li')(({ theme }) => ({
 
 const FileListItem = ({ file, onDelete }: FileListItemProps) => (
   <ListItem>
-    <Chip label={file.name} icon={<UploadFileIcon />} variant="outlined" sx={{ maxWidth: 200 }} onDelete={() => onDelete(file)} />
+    <Chip label={file.name} icon={!file.isLoading ? <CircularProgress size={20} /> : <UploadFileIcon />} variant="outlined" sx={{ maxWidth: 200 }} onDelete={() => onDelete(file)} />
   </ListItem>
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import type { ButtonProps, TypographyProps } from '@mui/material';
 import { Box, Button, FormControl, FormHelperText, Typography } from '@mui/material';
 import type { SxProps, Theme } from '@mui/system';
 import { DropzoneOptions, useDropzone } from 'react-dropzone';
-import FileListItem from './components/file-list-item';
+import FileListItem, { LoadingFile } from './components/file-list-item';
 
 export interface FileUploadProps extends Omit<DropzoneOptions, 'onDrop' | 'onDropAccepted'> {
   sx?: SxProps<Theme>;
@@ -11,9 +11,9 @@ export interface FileUploadProps extends Omit<DropzoneOptions, 'onDrop' | 'onDro
   buttonProps?: Omit<ButtonProps, 'onClick'>;
   title?: string;
   buttonText?: string;
-  value: File[];
-  onChange: (files: File[]) => void;
-  onDelete?: (file: File) => boolean
+  value: LoadingFile[];
+  onChange: (files: LoadingFile[]) => void;
+  onDelete?: (file: LoadingFile) => boolean
 }
 
 const FileUpload = ({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,24 +1,31 @@
-import CloudUploadIcon from '@mui/icons-material/CloudUpload';
-import type { ButtonProps, TypographyProps } from '@mui/material';
-import { Box, Button, FormControl, FormHelperText, Typography } from '@mui/material';
-import type { SxProps, Theme } from '@mui/system';
-import { DropzoneOptions, useDropzone } from 'react-dropzone';
-import FileListItem, { LoadingFile } from './components/file-list-item';
+import CloudUploadIcon from "@mui/icons-material/CloudUpload"
+import type { ButtonProps, TypographyProps } from "@mui/material"
+import { Box, Button, FormControl, FormHelperText, Typography } from "@mui/material"
+import type { SxProps, Theme } from "@mui/system"
+import { DropzoneOptions, useDropzone } from "react-dropzone"
+import FileListItem, { LoadingFile } from "./components/file-list-item"
 
-export interface FileUploadProps extends Omit<DropzoneOptions, 'onDrop' | 'onDropAccepted'> {
-  sx?: SxProps<Theme>;
-  typographyProps?: TypographyProps;
-  buttonProps?: Omit<ButtonProps, 'onClick'>;
-  title?: string;
-  buttonText?: string;
-  value: LoadingFile[];
-  onChange: (files: LoadingFile[]) => void;
+export { LoadingFile } from "./components/file-list-item"
+
+export const areEqualFiles = (a: LoadingFile, b: LoadingFile) =>
+  a.name === b.name && a.type === b.type && a.size === b.size && a.lastModified === b.lastModified
+
+export interface FileUploadProps extends Omit<DropzoneOptions, "onDrop" | "onDropAccepted"> {
+  sx?: SxProps<Theme>
+  typographyProps?: TypographyProps
+  buttonProps?: Omit<ButtonProps, "onClick">
+  title?: string
+  buttonText?: string
+  value: LoadingFile[]
+  onChange: (files: LoadingFile[]) => void
   onDelete?: (file: LoadingFile) => boolean
+  onAddFiles?: (newFiles: LoadingFile[]) => void
+  fileComparator?: (a: LoadingFile, b: LoadingFile) => boolean
 }
 
 const FileUpload = ({
   value,
-  onChange,
+  onChange = () => {},
   sx,
   title,
   buttonText,
@@ -27,26 +34,42 @@ const FileUpload = ({
   disabled,
   maxSize,
   onDelete = () => true,
+  onAddFiles: onAddFile = () => {},
+  fileComparator = areEqualFiles,
   ...options
 }: FileUploadProps) => {
+  const getNewFiles = (files: LoadingFile[]) =>
+    files.filter((file) => !value.some((currentFile) => fileComparator(file, currentFile)))
+
   const { fileRejections, getRootProps, getInputProps, open } = useDropzone({
     ...options,
     disabled,
     maxSize,
-    onDropAccepted: onChange,
+    onDropAccepted: (files: LoadingFile[]) => {
+      const newFiles = getNewFiles(files)
+      onAddFile(newFiles)
+      onChange([...value, ...newFiles])
+    },
     noClick: true,
     noKeyboard: true,
-  });
+  })
 
-  const isFileTooLarge = maxSize !== undefined && fileRejections.length > 0 && fileRejections[0].file.size > maxSize;
+  const isFileTooLarge =
+    maxSize !== undefined && fileRejections.length > 0 && fileRejections[0]!.file.size > maxSize
 
   const remove = (index: number) => {
-    const files = [...value];
-    files.splice(index, 1);
-    onChange(files);
-  };
+    const files = [...value]
+    files.splice(index, 1)
+    onChange(files)
+  }
 
-  const files = value?.map((file, i) => <FileListItem key={file.name} file={file} onDelete={(fileToDelete) => onDelete(fileToDelete) && remove(i)} />);
+  const files = value?.map((file, i) => (
+    <FileListItem
+      key={file.name}
+      file={file}
+      onDelete={(fileToDelete) => onDelete(fileToDelete) && remove(i)}
+    />
+  ))
 
   return (
     <Box
@@ -54,27 +77,40 @@ const FileUpload = ({
       sx={{
         border: 1,
         borderRadius: 1,
-        borderColor: 'rgba(0, 0, 0, 0.23)',
+        borderColor: "rgba(0, 0, 0, 0.23)",
         paddingY: 3,
         paddingX: 1,
-        '&:hover': {
-          borderColor: disabled ? undefined : 'text.primary',
+        "&:hover": {
+          borderColor: disabled ? undefined : "text.primary",
         },
-        '&:focus-within': {
-          borderColor: 'primary.main',
+        "&:focus-within": {
+          borderColor: "primary.main",
           borderWidth: 2,
         },
         ...sx,
-      }}>
+      }}
+    >
       <FormControl
         error={isFileTooLarge}
-        sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
         <input {...getInputProps()} />
-        <CloudUploadIcon sx={{ fontSize: 40 }} color={disabled ? 'disabled' : 'primary'} />
+        <CloudUploadIcon sx={{ fontSize: 40 }} color={disabled ? "disabled" : "primary"} />
         <Typography variant="caption" textAlign="center" sx={{ paddingY: 1 }} {...typographyProps}>
           {title}
         </Typography>
-        <Button variant="contained" onClick={open} disabled={disabled} sx={{ marginBottom: 1 }} {...buttonProps}>
+        <Button
+          variant="contained"
+          onClick={open}
+          disabled={disabled}
+          sx={{ marginBottom: 1 }}
+          {...buttonProps}
+        >
           {buttonText}
         </Button>
         <FormHelperText> {fileRejections[0]?.errors[0]?.message} </FormHelperText>
@@ -82,22 +118,23 @@ const FileUpload = ({
       <Box
         component="ul"
         sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-          listStyle: 'none',
+          display: "flex",
+          justifyContent: "center",
+          flexWrap: "wrap",
+          listStyle: "none",
           p: 0.5,
           m: 0,
-        }}>
+        }}
+      >
         {files}
       </Box>
     </Box>
-  );
-};
+  )
+}
 
 FileUpload.defaultProps = {
   title: "Drag 'n' drop some files here, or click to select files",
-  buttonText: 'Upload',
-};
+  buttonText: "Upload",
+}
 
-export default FileUpload;
+export default FileUpload

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ const FileUpload = ({
   disabled,
   maxSize,
   onDelete = () => true,
-  onAddFiles: onAddFile = () => {},
+  onAddFiles = () => {},
   fileComparator = areEqualFiles,
   ...options
 }: FileUploadProps) => {
@@ -47,7 +47,7 @@ const FileUpload = ({
     maxSize,
     onDropAccepted: (files: LoadingFile[]) => {
       const newFiles = getNewFiles(files)
-      onAddFile(newFiles)
+      onAddFiles(newFiles)
       onChange([...value, ...newFiles])
     },
     noClick: true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ export interface FileUploadProps extends Omit<DropzoneOptions, 'onDrop' | 'onDro
   buttonText?: string;
   value: File[];
   onChange: (files: File[]) => void;
+  onDelete?: (file: File) => boolean
 }
 
 const FileUpload = ({
@@ -25,6 +26,7 @@ const FileUpload = ({
   buttonProps,
   disabled,
   maxSize,
+  onDelete = () => true,
   ...options
 }: FileUploadProps) => {
   const { fileRejections, getRootProps, getInputProps, open } = useDropzone({
@@ -44,7 +46,7 @@ const FileUpload = ({
     onChange(files);
   };
 
-  const files = value?.map((file, i) => <FileListItem key={file.name} name={file.name} onDelete={() => remove(i)} />);
+  const files = value?.map((file, i) => <FileListItem key={file.name} file={file} onDelete={(fileToDelete) => onDelete(fileToDelete) && remove(i)} />);
 
   return (
     <Box


### PR DESCRIPTION
Adds a loading spinner and respective controls to the File Uploader.

Breaks previous versions due to the introduction of `LoadingFile`

Developers can now

- easily start a file upload upon addition and show/control a loading spinner
- react to and control the deletion of files or abortion of uploads by users

![grafik](https://user-images.githubusercontent.com/44174681/190989473-7ac58eb7-4f13-46e4-9c2c-86ea5e1d9747.png)
